### PR TITLE
update to work with proposals api change with list of instrument_types

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -45,7 +45,7 @@ function getProposals(){
 function suitabilityCheck(proposal_code){
     return $.getJSON(apiRoot + 'proposals/'+proposal_code+'/').then(function(data){
       for (i=0;i<data.timeallocation_set.length;i++){
-        if (data.timeallocation_set[i].instrument_type == '0M4-SCICAM-SBIG'){
+        if (data.timeallocation_set[i].instrument_types.includes('0M4-SCICAM-SBIG')){
           if (data.timeallocation_set[i].std_allocation >  data.timeallocation_set[i].std_time_used){
             return true
           }


### PR DESCRIPTION
We are deploying a change to the observation portal soon that allows multiple instrument_types per time_allocation. There is a small change to the proposals/ API for this, changing the singular instrument_type per timeallocation to be a list of instrument_types. I think this update should fix things - I can deploy it after I deploy the updated observation portal if you are happy with the change.